### PR TITLE
Check route exists, when route not exists the function getName is not…

### DIFF
--- a/src/Middleware/LaravelMinifyHtml.php
+++ b/src/Middleware/LaravelMinifyHtml.php
@@ -21,7 +21,8 @@ class LaravelMinifyHtml
             $this->isResponseObject($response) &&
             $this->isHtmlResponse($response) &&
             Config::get('htmlminify.default') &&
-            !$this->isRouteExclude($request)
+            !$this->isRouteExclude($request) &&
+            !$this->isErrorServer($response)
         ) {
             $response->setContent(LaravelHtmlMinifyFacade::htmlMinify($response->getContent()));
         }
@@ -55,6 +56,11 @@ class LaravelMinifyHtml
         if (!$request->route()) {
             return false;
         }
-        return in_array($request->route()->getName(),config('htmlminify.exclude_route', []));
+        return in_array($request->route()->getName(), config('htmlminify.exclude_route', []));
+    }
+
+    protected function isErrorServer($response): bool
+    {
+        return in_array($response->getStatusCode(), config('htmlminify.status_server_error', []));
     }
 }

--- a/src/Middleware/LaravelMinifyHtml.php
+++ b/src/Middleware/LaravelMinifyHtml.php
@@ -52,6 +52,9 @@ class LaravelMinifyHtml
      */
     protected function isRouteExclude($request): bool
     {
+        if (!$request->route()) {
+            return false;
+        }
         return in_array($request->route()->getName(),config('htmlminify.exclude_route', []));
     }
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -14,6 +14,20 @@ return [
 
     // exclude route name for exclude from minify
     'exclude_route' => [
-        // 'routeName'
-    ]
+        // 'routeName'htmlminify.exclude_route
+    ],
+    
+    'status_server_error' => [
+        500,
+        501,
+        502,
+        503,
+        504,
+        505,
+        506,
+        507,
+        508,
+        510,
+        511
+    ],
 ];


### PR DESCRIPTION
Add Check route exists!
Because when route not exists the function getName is not found. an error is generated error:Call to a member function getName() returning error 500 and not 404.